### PR TITLE
Update debug-logger.js

### DIFF
--- a/addon/initializers/debug-logger.js
+++ b/addon/initializers/debug-logger.js
@@ -1,6 +1,6 @@
 import debugLogger from 'ember-debug-logger/utils/debug-logger';
 
-export function initialize(container, app) {
+export function initialize(app) {
   app.register('debug-logger:main', debugLogger(), { instantiate: false });
 
   ['route', 'component', 'controller', 'service'].forEach(function(type) {


### PR DESCRIPTION
Clear deprecated error for Ember 2.x 
"DEPRECATION: The `initialize` method for Application initializer 'debug-logger' should take only one argument "