### PR TITLE
Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,18 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
- sudo: false
+  - "6"
+
+sudo: false
 dist: trusty
- addons:
+
+addons:
   chrome: stable
- cache:
+
+cache:
   yarn: true
- env:
+
+env:
   global:
     # See https://git.io/vdao3 for details.
     - JOBS=1
@@ -23,16 +27,20 @@ dist: trusty
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default
- matrix:
+
+matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
- before_install:
+
+before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
- install:
+
+install:
   - yarn install --no-lockfile --non-interactive
- script:
+
+script:
   - yarn lint:js
   - yarn lint:ts
   # Usually, it's ok to finish the test scenario without reverting

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+---
+language: node_js
+node_js:
+  # we recommend testing addons with the same minimum supported node version as Ember CLI
+  # so that your addon works for all apps
+  - "4"
+ sudo: false
+dist: trusty
+ addons:
+  chrome: stable
+ cache:
+  yarn: true
+ env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+  matrix:
+    # we recommend new addons test the current and previous LTS
+    # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-beta
+    - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=ember-default
+ matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
+ before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+ install:
+  - yarn install --no-lockfile --non-interactive
+ script:
+  - yarn lint:js
+  - yarn lint:ts
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,12 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
   matrix:
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.12
     - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
-    - EMBER_TRY_SCENARIO=ember-default
+    - EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",


### PR DESCRIPTION
Accidentally removed .travis.yml - This PR puts it back so we have CI testing.
We also deprecate Node 4 in our testing, requiring a minimum of Node 6.

PR Prime: @dfreeman 